### PR TITLE
Add new `.find_all_by_tz_name` and `.find_all_by_timezone` finders

### DIFF
--- a/lib/airports.rb
+++ b/lib/airports.rb
@@ -25,6 +25,14 @@ module Airports
     all.select { |airport| airport.country.casecmp(country_name).zero? }
   end
 
+  def self.find_all_by_tz_name(tzname)
+    all.find { |airport| airport.tzname == tzname }
+  end
+
+  def self.find_all_by_timezne(timezone)
+    all.select { |airport| airport.timezone == timezone }
+  end
+
   def self.iata_codes
     parsed_data.keys
   end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1707f3d7e9815ff2046d5fd6bb4e22047fa41d54  | 
|--------|--------|

### Summary:
Added `find_all_by_tz_name` and `find_all_by_timezone` methods to the `Airports` module in `lib/airports.rb`.

**Key points**:
- Added `Airports.find_all_by_tz_name(tzname)` to find airports by `tzname`.
- Added `Airports.find_all_by_timezne(timezone)` to find airports by `timezone`.
- Changes made in `lib/airports.rb`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->